### PR TITLE
changing zip instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install git+https://github.com/datamade/dedupe.git@gazetteer#egg=dedupe
 You will need a Gazetteer of all unique addresses in a given area. For this example, we used the [Building Footprints shapefile](https://data.cityofchicago.org/Buildings/Building-Footprints/qv97-3bvb) and extracted the table attributes from the DBF file using csvkit. This file is in the `data` folder and should be unzipped if you want to use it.
 
 ```bash
-cv data
+cd data
 unzip building_footprints.csv.zip
 ```
 


### PR DESCRIPTION
If you unzip from project root using that unzip command, the file actually gets sent to the root, and then the address_matching script can't find the file when you execute it.
